### PR TITLE
Fix HTTP driver bug if multiple link elements are on the same line

### DIFF
--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -9,6 +9,7 @@ use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
 
 class HttpDriver implements Fetcher
 {
@@ -93,9 +94,17 @@ class HttpDriver implements Fetcher
 
         preg_match($pattern, $html, $linkElement);
 
-        return isset($linkElement[0])
-            ? strstr($linkElement[0], '>', true)
-            : null;
+        if (!isset($linkElement[0])) {
+            return null;
+        }
+
+        // If multiple link elements were found in the HTML, we need to loop
+        // through and only grab the "shortcut icon" or "icon" link.
+        return collect(explode('>', $linkElement[0]))
+            ->filter(
+                fn (string $link): bool => Str::is(['*rel="shortcut icon"*', '*rel="icon"*'], $link)
+            )
+            ->first();
     }
 
     /**

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -248,6 +248,10 @@ class HttpDriverTest extends TestCase
             $this->htmlOptionThree(),
             $this->htmlOptionFour(),
             $this->htmlOptionFive(),
+            $this->htmlOptionSix(),
+            $this->htmlOptionSeven(),
+            $this->htmlOptionEight(),
+            $this->htmlOptionNine(),
         ];
     }
 
@@ -304,5 +308,77 @@ class HttpDriverTest extends TestCase
         HTML;
 
         return [$responseHtml, 'https://example.com/icon/is/here.ico'];
+    }
+
+    private function htmlOptionSix(): array
+    {
+        $responseHtml = <<<'HTML'
+            <head> <title>Title here</title> <meta name="description" content="Meta description here"> <meta charset="utf-8"> <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> <meta http-equiv="X-UA-Compatible" content="IE=edge"> <link rel="alternate" href="https://www.example.lv" hreflang="lv"> <link rel="alternate" href="https://www.example.lt/" hreflang="lt"> <link rel="alternate" href="https://www.example.ee/" hreflang="ee"> <link rel="alternate" href="https://www.example.ru/" hreflang="ru"> <link rel="alternate" href="https://www.example.com/en/" hreflang="en"> <link rel="alternate" href="https://www.example.com/default" hreflang="x-default"> <meta name="theme-color" content="#FFFFFF"> <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icon-180x180.png"> <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico"> <link rel="stylesheet" href="/css/app.css?id=123"> <script src="/vendor/livewire/livewire.js?id=456" data-turbo-eval="false" data-turbolinks-eval="false" ></script><script data-turbo-eval="false" data-turbolinks-eval="false" >
+        HTML;
+
+        return [$responseHtml, 'https://example.com/images/favicon.ico'];
+    }
+
+    private function htmlOptionSeven(): array
+    {
+        $responseHtml = <<<'HTML'
+            <head>
+                <title>Title here</title>
+                <meta name="description" content="Meta description here">
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+                <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                <link rel="alternate" href="https://www.example.lv" hreflang="lv">
+                <link rel="alternate" href="https://www.example.lt/" hreflang="lt">
+                <link rel="alternate" href="https://www.example.ee/" hreflang="ee">
+                <link rel="alternate" href="https://www.example.ru/" hreflang="ru">
+                <link rel="alternate" href="https://www.example.com/en/" hreflang="en">
+                <link rel="alternate" href="https://www.example.com/default" hreflang="x-default">
+                <meta name="theme-color" content="#FFFFFF">
+                <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icon-180x180.png">
+                <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico">
+                <link rel="stylesheet" href="/css/app.css?id=123">
+                <script src="/vendor/livewire/livewire.js?id=456" data-turbo-eval="false" data-turbolinks-eval="false" ></script>
+                <script data-turbo-eval="false" data-turbolinks-eval="false" ></script>
+            </head>
+        HTML;
+
+        return [$responseHtml, 'https://example.com/images/favicon.ico'];
+    }
+
+    private function htmlOptionEight(): array
+    {
+        $responseHtml = <<<'HTML'
+            <head> <title>Title here</title> <meta name="description" content="Meta description here"> <meta charset="utf-8"> <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> <meta http-equiv="X-UA-Compatible" content="IE=edge"> <link rel="alternate" href="https://www.example.lv" hreflang="lv"> <link rel="alternate" href="https://www.example.lt/" hreflang="lt"> <link rel="alternate" href="https://www.example.ee/" hreflang="ee"> <link rel="alternate" href="https://www.example.ru/" hreflang="ru"> <link rel="alternate" href="https://www.example.com/en/" hreflang="en"> <link rel="alternate" href="https://www.example.com/default" hreflang="x-default"> <meta name="theme-color" content="#FFFFFF"> <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icon-180x180.png"> <link rel="icon" type="image/x-icon" href="/images/favicon.ico"> <link rel="stylesheet" href="/css/app.css?id=123"> <script src="/vendor/livewire/livewire.js?id=456" data-turbo-eval="false" data-turbolinks-eval="false" ></script><script data-turbo-eval="false" data-turbolinks-eval="false" >
+        HTML;
+
+        return [$responseHtml, 'https://example.com/images/favicon.ico'];
+    }
+
+    private function htmlOptionNine(): array
+    {
+        $responseHtml = <<<'HTML'
+            <head>
+                <title>Title here</title>
+                <meta name="description" content="Meta description here">
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+                <meta http-equiv="X-UA-Compatible" content="IE=edge">
+                <link rel="alternate" href="https://www.example.lv" hreflang="lv">
+                <link rel="alternate" href="https://www.example.lt/" hreflang="lt">
+                <link rel="alternate" href="https://www.example.ee/" hreflang="ee">
+                <link rel="alternate" href="https://www.example.ru/" hreflang="ru">
+                <link rel="alternate" href="https://www.example.com/en/" hreflang="en">
+                <link rel="alternate" href="https://www.example.com/default" hreflang="x-default">
+                <meta name="theme-color" content="#FFFFFF">
+                <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icon-180x180.png">
+                <link rel="icon" type="image/x-icon" href="/images/favicon.ico">
+                <link rel="stylesheet" href="/css/app.css?id=123">
+                <script src="/vendor/livewire/livewire.js?id=456" data-turbo-eval="false" data-turbolinks-eval="false" ></script>
+                <script data-turbo-eval="false" data-turbolinks-eval="false" ></script>
+            </head>
+        HTML;
+
+        return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
 }


### PR DESCRIPTION
This PR fixes a bug in the HTTP driver that was using the wrong `<link>` tag while parsing the HTML.

This bug happened if there were multiple `<link>` tags on the same line in the HTML. The `preg_match` function was grabbing the entire line and then we were returning the first link in the matches. So, this would return whichever link element was the first on the line.

Now, the code will explode the line and loop through the links to find the "icon" or "shortcut icon" element.