### PR TITLE
Fixed bug that was using the wrong file extension when storing favicons

### DIFF
--- a/src/Favicon.php
+++ b/src/Favicon.php
@@ -141,6 +141,36 @@ class Favicon
             ->append('/')
             ->append($filename)
             ->append('.')
-            ->append(File::extension($this->faviconUrl));
+            ->append($this->guessFileExtension());
+    }
+
+    protected function guessFileExtension(): string
+    {
+        $default = File::extension($this->faviconUrl);
+
+        if (Str::of($this->faviconUrl)->endsWith(['png', 'ico', 'svg'])) {
+            return $default;
+        }
+
+        return $this->guessFileExtensionFromMimeType() ?? $default;
+    }
+
+    protected function guessFileExtensionFromMimeType(): ?string
+    {
+        $faviconMimetype = Http::get($this->faviconUrl)->header('content-type');
+
+        $mimeToExtensionMap = [
+            'image/x-icon' => 'ico',
+            'image/x-ico' => 'ico',
+            'image/vnd.microsoft.icon' => 'ico',
+            'text/calendar' => 'ics',
+            'image/jpeg' => 'jpeg',
+            'image/pjpeg' => 'jpeg',
+            'image/png' => 'png',
+            'image/x-png' => 'png',
+            'image/svg+xml' => 'svg',
+        ];
+
+        return $mimeToExtensionMap[$faviconMimetype] ?? null;
     }
 }


### PR DESCRIPTION
This PR fixes a bug that was storing the favicons with the incorrect file extension when using any driver apart from the `http` driver.