### PR TITLE
Remove incorrect mime type and extension

### DIFF
--- a/src/Favicon.php
+++ b/src/Favicon.php
@@ -163,7 +163,6 @@ class Favicon
             'image/x-icon' => 'ico',
             'image/x-ico' => 'ico',
             'image/vnd.microsoft.icon' => 'ico',
-            'text/calendar' => 'ics',
             'image/jpeg' => 'jpeg',
             'image/pjpeg' => 'jpeg',
             'image/png' => 'png',


### PR DESCRIPTION
When I originally added this list, I used a list from a Stack Overflow post. It looks like I accidentally left a `text/calendar` mime type in there accidentally.

This PR removes the incorrect mime type 🙂