### PR TITLE
Allow element attributes in single quotes

### DIFF
--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -102,7 +102,12 @@ class HttpDriver implements Fetcher
         // through and only grab the "shortcut icon" or "icon" link.
         return collect(explode('>', $linkElement[0]))
             ->filter(
-				fn (string $link): bool => Str::is(['*rel=*shortcut icon*', '*rel=*icon*'], $link)
+                fn (string $link): bool => Str::is([
+                    '*rel="shortcut icon"*',
+                    '*rel="icon"*',
+                    "*rel='shortcut icon'*",
+                    "*rel='icon'*",
+                ], $link)
             )
             ->first();
     }
@@ -116,13 +121,14 @@ class HttpDriver implements Fetcher
     private function parseLinkFromElement(string $linkElement): string
     {
         $stringUntilHref = strstr($linkElement, 'href="');
-		if(!$stringUntilHref)
-		{
-			$stringUntilHref = strstr($linkElement, "href='");
-		}
 
-		// replacing quotes to delimiter
-		$stringUntilHref = str_replace(['"', '\''], '|', $stringUntilHref);
+        if (!$stringUntilHref) {
+            $stringUntilHref = strstr($linkElement, "href='");
+        }
+
+        // Replace the double or single quotes with a common delimiter
+        // that can be used for exploding the string.
+        $stringUntilHref = str_replace(['"', '\''], '|', $stringUntilHref);
 
         return explode('|', $stringUntilHref)[1];
     }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -90,7 +90,7 @@ class HttpDriver implements Fetcher
      */
     private function findLinkElement(string $html): ?string
     {
-        $pattern = '/<link.*rel="(icon|shortcut icon)"[^>]*>/i';
+        $pattern = '/<link.*rel=["\'](icon|shortcut icon)["\'][^>]*>/i';
 
         preg_match($pattern, $html, $linkElement);
 
@@ -102,7 +102,7 @@ class HttpDriver implements Fetcher
         // through and only grab the "shortcut icon" or "icon" link.
         return collect(explode('>', $linkElement[0]))
             ->filter(
-                fn (string $link): bool => Str::is(['*rel="shortcut icon"*', '*rel="icon"*'], $link)
+				fn (string $link): bool => Str::is(['*rel=*shortcut icon*', '*rel=*icon*'], $link)
             )
             ->first();
     }
@@ -116,8 +116,15 @@ class HttpDriver implements Fetcher
     private function parseLinkFromElement(string $linkElement): string
     {
         $stringUntilHref = strstr($linkElement, 'href="');
+		if(!$stringUntilHref)
+		{
+			$stringUntilHref = strstr($linkElement, "href='");
+		}
 
-        return explode('"', $stringUntilHref)[1];
+		// replacing quotes to delimiter
+		$stringUntilHref = str_replace(['"', '\''], '|', $stringUntilHref);
+
+        return explode('|', $stringUntilHref)[1];
     }
 
     /**

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -122,7 +122,7 @@ class HttpDriver implements Fetcher
     {
         $stringUntilHref = strstr($linkElement, 'href="');
 
-        if (!$stringUntilHref) {
+        if (! $stringUntilHref) {
             $stringUntilHref = strstr($linkElement, "href='");
         }
 

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -382,7 +382,7 @@ class HttpDriverTest extends TestCase
 
         return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
-    
+
     private function htmlOptionTen(): array
     {
         $responseHtml = <<<'HTML'

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -398,5 +398,4 @@ class HttpDriverTest extends TestCase
 
         return [$responseHtml, 'https://www.example.com/favicon123.ico'];
     }
-
 }

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -383,9 +383,9 @@ class HttpDriverTest extends TestCase
         return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
     
-	private function htmlOptionTen(): array
-	{
-		$responseHtml = <<<'HTML'
+    private function htmlOptionTen(): array
+    {
+        $responseHtml = <<<'HTML'
             <head>
                 <title>Test Title</title>
                 <meta content='IE=edge' http-equiv='X-UA-Compatible'>
@@ -396,6 +396,7 @@ class HttpDriverTest extends TestCase
             </head>
         HTML;
 
-		return [$responseHtml, 'https://www.example.com/favicon123.ico'];
-	}
+        return [$responseHtml, 'https://www.example.com/favicon123.ico'];
+    }
+
 }

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -252,6 +252,7 @@ class HttpDriverTest extends TestCase
             $this->htmlOptionSeven(),
             $this->htmlOptionEight(),
             $this->htmlOptionNine(),
+            $this->htmlOptionTen(),
         ];
     }
 
@@ -381,4 +382,20 @@ class HttpDriverTest extends TestCase
 
         return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
+    
+	private function htmlOptionTen(): array
+	{
+		$responseHtml = <<<'HTML'
+            <head>
+                <title>Test Title</title>
+                <meta content='IE=edge' http-equiv='X-UA-Compatible'>
+                <meta content='telephone=no' name='format-detection'>
+                <meta content='width=device-width, initial-scale=1, maximum-scale=1' name='viewport'>
+                <link href='https://www.example.com/favicon123.png' rel='apple-touch-icon'>
+                <link href='https://www.example.com/favicon123.ico' rel='shortcut icon' type='image/x-icon'>
+            </head>
+        HTML;
+
+		return [$responseHtml, 'https://www.example.com/favicon123.ico'];
+	}
 }


### PR DESCRIPTION
This fix tries to fetch favicon when icon href is using single quotes instead of double.

Example:
`<link href='https://www.1a.lv/assets/themes/1a/favicon-c97bcf2fe300f089a14f027f6302d7d1bf0767561b811612e375f48dccdff6d0.ico' rel='shortcut icon' type='image/x-icon'>`