### PR TITLE
Get the favicon's size and type

### DIFF
--- a/src/Collections/FaviconCollection.php
+++ b/src/Collections/FaviconCollection.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AshAllenDesign\FaviconFetcher\Collections;
+
+use Illuminate\Support\Collection;
+
+class FaviconCollection extends Collection
+{
+
+}

--- a/src/Concerns/HasDefaultFunctionality.php
+++ b/src/Concerns/HasDefaultFunctionality.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\FaviconFetcher\Concerns;
 
+use AshAllenDesign\FaviconFetcher\Exceptions\FaviconFetcherException;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Facades\Favicon;
@@ -138,13 +139,28 @@ trait HasDefaultFunctionality
     /**
      * Return the cached favicon, if one exists, or return null.
      *
-     * @param  string  $url
+     * @param string $url
      * @return FetchedFavicon|null
+     * @throws FaviconFetcherException
      */
     protected function attemptToFetchFromCache(string $url): ?FetchedFavicon
     {
-        $cachedFaviconUrl = Cache::get($this->buildCacheKey($url));
+        $cachedFaviconData = Cache::get($this->buildCacheKey($url));
 
-        return $cachedFaviconUrl ? FetchedFavicon::makeFromCache($url, $cachedFaviconUrl) : null;
+        if (!$cachedFaviconData) {
+            return null;
+        }
+
+        if (!is_array($cachedFaviconData)) {
+            throw new FaviconFetcherException('The cached favicon data is not a valid array.');
+        }
+
+        return (new FetchedFavicon(
+            url: $url,
+            faviconUrl: $cachedFaviconData['favicon_url'],
+            retrievedFromCache: true,
+        ))
+            ->setIconType($cachedFaviconData['icon_type'])
+            ->setIconSize($cachedFaviconData['icon_size']);
     }
 }

--- a/src/Contracts/Fetcher.php
+++ b/src/Contracts/Fetcher.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\FaviconFetcher\Contracts;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
@@ -15,6 +16,14 @@ interface Fetcher
      * @return Favicon|null
      */
     public function fetch(string $url): ?Favicon;
+
+    /**
+     * Attempt to fetch all favicons and icons for the given URL.
+     *
+     * @param string $url
+     * @return FaviconCollection
+     */
+    public function fetchAll(string $url): FaviconCollection;
 
     /**
      * Attempt to fetch the favicon for the given URL. If a favicon cannot

--- a/src/Drivers/FaviconGrabberDriver.php
+++ b/src/Drivers/FaviconGrabberDriver.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\FaviconFetcher\Drivers;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
 use AshAllenDesign\FaviconFetcher\Concerns\ValidatesUrls;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
@@ -49,5 +50,10 @@ class FaviconGrabberDriver implements Fetcher
         $faviconUrl = $response->json('icons')[0]['src'];
 
         return new Favicon($url, $faviconUrl, $this);
+    }
+
+    public function fetchAll(string $url): FaviconCollection
+    {
+        // TODO Implement this method.
     }
 }

--- a/src/Drivers/FaviconGrabberDriver.php
+++ b/src/Drivers/FaviconGrabberDriver.php
@@ -49,7 +49,7 @@ class FaviconGrabberDriver implements Fetcher
 
         $faviconUrl = $response->json('icons')[0]['src'];
 
-        return new Favicon($url, $faviconUrl, $this);
+        return new Favicon(url: $url, faviconUrl: $faviconUrl, fromDriver: $this);
     }
 
     public function fetchAll(string $url): FaviconCollection

--- a/src/Drivers/FaviconKitDriver.php
+++ b/src/Drivers/FaviconKitDriver.php
@@ -44,7 +44,9 @@ class FaviconKitDriver implements Fetcher
 
         $response = Http::get($faviconUrl);
 
-        return $response->successful() ? new Favicon($url, $faviconUrl, $this) : $this->notFound($url);
+        return $response->successful()
+            ? new Favicon(url: $url, faviconUrl: $faviconUrl, fromDriver: $this)
+            : $this->notFound($url);
     }
 
     public function fetchAll(string $url): FaviconCollection

--- a/src/Drivers/FaviconKitDriver.php
+++ b/src/Drivers/FaviconKitDriver.php
@@ -2,10 +2,12 @@
 
 namespace AshAllenDesign\FaviconFetcher\Drivers;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
 use AshAllenDesign\FaviconFetcher\Concerns\ValidatesUrls;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
+use AshAllenDesign\FaviconFetcher\Exceptions\FeatureNotSupportedException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Illuminate\Support\Facades\Http;
@@ -43,5 +45,10 @@ class FaviconKitDriver implements Fetcher
         $response = Http::get($faviconUrl);
 
         return $response->successful() ? new Favicon($url, $faviconUrl, $this) : $this->notFound($url);
+    }
+
+    public function fetchAll(string $url): FaviconCollection
+    {
+        throw new FeatureNotSupportedException('The FaviconKit API does not support fetching all favicons.');
     }
 }

--- a/src/Drivers/GoogleSharedStuffDriver.php
+++ b/src/Drivers/GoogleSharedStuffDriver.php
@@ -42,7 +42,9 @@ class GoogleSharedStuffDriver implements Fetcher
 
         $response = Http::get($faviconUrl);
 
-        return $response->successful() ? new Favicon($url, $faviconUrl, $this) : $this->notFound($url);
+        return $response->successful()
+            ? new Favicon(url: $url, faviconUrl: $faviconUrl, fromDriver: $this)
+            : $this->notFound($url);
     }
 
     public function fetchAll(string $url): FaviconCollection

--- a/src/Drivers/GoogleSharedStuffDriver.php
+++ b/src/Drivers/GoogleSharedStuffDriver.php
@@ -2,10 +2,12 @@
 
 namespace AshAllenDesign\FaviconFetcher\Drivers;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
 use AshAllenDesign\FaviconFetcher\Concerns\ValidatesUrls;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
+use AshAllenDesign\FaviconFetcher\Exceptions\FeatureNotSupportedException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Illuminate\Support\Facades\Http;
@@ -41,5 +43,10 @@ class GoogleSharedStuffDriver implements Fetcher
         $response = Http::get($faviconUrl);
 
         return $response->successful() ? new Favicon($url, $faviconUrl, $this) : $this->notFound($url);
+    }
+
+    public function fetchAll(string $url): FaviconCollection
+    {
+        throw new FeatureNotSupportedException('The Google Shared Stuff API does not support fetching all favicons.');
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -42,7 +42,7 @@ class HttpDriver implements Fetcher
         $favicon = $this->attemptToResolveFromHeadTags($url)
             ?? new Favicon(url: $url, faviconUrl: $this->guessDefaultUrl($url), fromDriver: $this);
 
-        $faviconCanBeReached = $this->attemptToResolveFromUrl($favicon->getFaviconUrl());
+        $faviconCanBeReached = $this->faviconUrlCanBeReached($favicon->getFaviconUrl());
 
         return $faviconCanBeReached
             ? $favicon
@@ -86,18 +86,12 @@ class HttpDriver implements Fetcher
      * is successful, we can assume that a valid favicon was returned.
      * Otherwise, we can assume that a favicon wasn't found.
      *
-     * @param  string  $url
-     * @param  string  $faviconUrl
-     * @return Favicon|null
+     * @param string $faviconUrl
+     * @return bool
      */
-    private function attemptToResolveFromUrl(string $faviconUrl): bool
+    private function faviconUrlCanBeReached(string $faviconUrl): bool
     {
         return Http::get($faviconUrl)->successful();
-
-        // TODO Attempt to resolve the icon type.
-        // TODO Attempt to resolve the icon size here.
-
-        return $response->successful() ? new Favicon($url, $faviconUrl, null, null, $this) : null;
     }
 
     /**

--- a/src/Drivers/UnavatarDriver.php
+++ b/src/Drivers/UnavatarDriver.php
@@ -44,7 +44,9 @@ class UnavatarDriver implements Fetcher
 
         $response = Http::get($faviconUrl);
 
-        return $response->successful() ? new Favicon($url, $faviconUrl, $this) : $this->notFound($url);
+        return $response->successful()
+            ? new Favicon(url: $url, faviconUrl: $faviconUrl, fromDriver: $this)
+            : $this->notFound($url);
     }
 
     public function fetchAll(string $url): FaviconCollection

--- a/src/Drivers/UnavatarDriver.php
+++ b/src/Drivers/UnavatarDriver.php
@@ -2,10 +2,12 @@
 
 namespace AshAllenDesign\FaviconFetcher\Drivers;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Concerns\HasDefaultFunctionality;
 use AshAllenDesign\FaviconFetcher\Concerns\ValidatesUrls;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
+use AshAllenDesign\FaviconFetcher\Exceptions\FeatureNotSupportedException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Illuminate\Support\Facades\Http;
@@ -43,5 +45,10 @@ class UnavatarDriver implements Fetcher
         $response = Http::get($faviconUrl);
 
         return $response->successful() ? new Favicon($url, $faviconUrl, $this) : $this->notFound($url);
+    }
+
+    public function fetchAll(string $url): FaviconCollection
+    {
+        throw new FeatureNotSupportedException('The Unavatar API does not support fetching all favicons.');
     }
 }

--- a/src/Exceptions/FeatureNotSupportedException.php
+++ b/src/Exceptions/FeatureNotSupportedException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AshAllenDesign\FaviconFetcher\Exceptions;
+
+class FeatureNotSupportedException extends FaviconFetcherException
+{
+    //
+}

--- a/src/Exceptions/InvalidIconSizeException.php
+++ b/src/Exceptions/InvalidIconSizeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AshAllenDesign\FaviconFetcher\Exceptions;
+
+class InvalidIconSizeException extends FaviconFetcherException
+{
+    //
+}

--- a/src/Exceptions/InvalidIconTypeException.php
+++ b/src/Exceptions/InvalidIconTypeException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace AshAllenDesign\FaviconFetcher\Exceptions;
+
+class InvalidIconTypeException extends FaviconFetcherException
+{
+    //
+}

--- a/src/Favicon.php
+++ b/src/Favicon.php
@@ -146,7 +146,11 @@ class Favicon
     public function cache(CarbonInterface $ttl, bool $force = false): self
     {
         if ($force || ! $this->retrievedFromCache) {
-            Cache::put($this->buildCacheKey($this->url), $this->getFaviconUrl(), $ttl);
+            Cache::put(
+                $this->buildCacheKey($this->url),
+                $this->toCache(),
+                $ttl
+            );
         }
 
         return $this;
@@ -240,5 +244,19 @@ class Favicon
                 self::TYPE_ICON_UNKNOWN,
             ],
             strict: true);
+    }
+
+    /**
+     * Transform the favicon object into an array that can be cached.
+     *
+     * @return array
+     */
+    private function toCache(): array
+    {
+        return [
+            'favicon_url' => $this->getFaviconUrl(),
+            'icon_size' => $this->getIconSize(),
+            'icon_type' => $this->getIconType(),
+        ];
     }
 }

--- a/tests/Feature/Drivers/FaviconGrabberDriverTest.php
+++ b/tests/Feature/Drivers/FaviconGrabberDriverTest.php
@@ -5,6 +5,7 @@ namespace AshAllenDesign\FaviconFetcher\Tests\Feature\Drivers;
 use AshAllenDesign\FaviconFetcher\Drivers\FaviconGrabberDriver;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
+use AshAllenDesign\FaviconFetcher\Favicon;
 use AshAllenDesign\FaviconFetcher\FetcherManager;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\CustomDriver;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\NullDriver;
@@ -40,7 +41,11 @@ class FaviconGrabberDriverTest extends TestCase
     {
         Cache::put(
             'favicon-fetcher.aws.amazon.com',
-            'url-goes-here',
+            [
+                'favicon_url' => 'url-goes-here',
+                'icon_size' => null,
+                'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+            ],
             now()->addHour()
         );
 

--- a/tests/Feature/Drivers/FaviconKitDriverTest.php
+++ b/tests/Feature/Drivers/FaviconKitDriverTest.php
@@ -5,6 +5,7 @@ namespace AshAllenDesign\FaviconFetcher\Tests\Feature\Drivers;
 use AshAllenDesign\FaviconFetcher\Drivers\FaviconKitDriver;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
+use AshAllenDesign\FaviconFetcher\Favicon;
 use AshAllenDesign\FaviconFetcher\FetcherManager;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\CustomDriver;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\NullDriver;
@@ -40,7 +41,11 @@ class FaviconKitDriverTest extends TestCase
     {
         Cache::put(
             'favicon-fetcher.example.com',
-            'url-goes-here',
+            [
+                'favicon_url' => 'url-goes-here',
+                'icon_size' => null,
+                'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+            ],
             now()->addHour()
         );
 

--- a/tests/Feature/Drivers/GoogleSharedStuffDriverTest.php
+++ b/tests/Feature/Drivers/GoogleSharedStuffDriverTest.php
@@ -5,6 +5,7 @@ namespace AshAllenDesign\FaviconFetcher\Tests\Feature\Drivers;
 use AshAllenDesign\FaviconFetcher\Drivers\GoogleSharedStuffDriver;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
+use AshAllenDesign\FaviconFetcher\Favicon;
 use AshAllenDesign\FaviconFetcher\FetcherManager;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\CustomDriver;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\NullDriver;
@@ -40,7 +41,11 @@ class GoogleSharedStuffDriverTest extends TestCase
     {
         Cache::put(
             'favicon-fetcher.example.com',
-            'url-goes-here',
+            [
+                'favicon_url' => 'url-goes-here',
+                'icon_size' => null,
+                'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+            ],
             now()->addHour()
         );
 

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -87,7 +87,11 @@ class HttpDriverTest extends TestCase
     {
         Cache::put(
             'favicon-fetcher.example.com',
-            'url-goes-here',
+            [
+                'favicon_url' => 'url-goes-here',
+                'icon_size' => null,
+                'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+            ],
             now()->addHour()
         );
 

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -24,8 +24,12 @@ class HttpDriverTest extends TestCase
      *
      * @dataProvider faviconLinksInHtmlProvider
      */
-    public function favicon_can_be_fetched_using_link_element_in_html(string $html, string $expectedFaviconUrl): void
-    {
+    public function favicon_can_be_fetched_using_link_element_in_html(
+        string $html,
+        string $expectedFaviconUrl,
+        ?int $expectedSize,
+        string $expectedType,
+    ): void {
         Http::fake([
             'https://example.com' => Http::response($html),
             $expectedFaviconUrl => Http::response('favicon contents here'),
@@ -35,6 +39,8 @@ class HttpDriverTest extends TestCase
         $favicon = (new HttpDriver())->fetch('https://example.com');
 
         self::assertSame($expectedFaviconUrl, $favicon->getFaviconUrl());
+        self::assertSame($expectedSize, $favicon->getIconSize());
+        self::assertSame($expectedType, $favicon->getIconType());
     }
 
     /** @test */
@@ -312,17 +318,17 @@ class HttpDriverTest extends TestCase
     public function faviconLinksInHtmlProvider(): array
     {
         return [
-            [$this->htmlOptionOne(), 'https://example.com/icon/is/here.ico'],
-            [$this->htmlOptionTwo(), 'https://example.com/icon/is/here.ico'],
-            [$this->htmlOptionThree(), 'https://example.com/icon/is/here.ico'],
-            [$this->htmlOptionFour(), 'https://example.com/favicon/favicon-32x32.png'],
-            [$this->htmlOptionFive(), 'https://example.com/icon/is/here.ico'],
-            [$this->htmlOptionSix(), 'https://example.com/images/favicon.ico'],
-            [$this->htmlOptionSeven(), 'https://example.com/images/favicon.ico'],
-            [$this->htmlOptionEight(), 'https://example.com/images/favicon.ico'],
-            [$this->htmlOptionNine(), 'https://example.com/images/favicon.ico'],
-            [$this->htmlOptionTen(), 'https://www.example.com/favicon123.ico'],
-            [$this->htmlOptionEleven(), 'https://example.com/android-icon-192x192.png'],
+            [$this->htmlOptionOne(), 'https://example.com/icon/is/here.ico', null, Favicon::TYPE_ICON],
+            [$this->htmlOptionTwo(), 'https://example.com/icon/is/here.ico', null, Favicon::TYPE_ICON],
+            [$this->htmlOptionThree(), 'https://example.com/icon/is/here.ico', null, Favicon::TYPE_SHORTCUT_ICON],
+            [$this->htmlOptionFour(), 'https://example.com/favicon/favicon-32x32.png', null, Favicon::TYPE_ICON],
+            [$this->htmlOptionFive(), 'https://example.com/icon/is/here.ico', null, Favicon::TYPE_SHORTCUT_ICON],
+            [$this->htmlOptionSix(), 'https://example.com/images/favicon.ico', null, Favicon::TYPE_SHORTCUT_ICON],
+            [$this->htmlOptionSeven(), 'https://example.com/images/favicon.ico', null, Favicon::TYPE_SHORTCUT_ICON],
+            [$this->htmlOptionEight(), 'https://example.com/images/favicon.ico', null, Favicon::TYPE_ICON],
+            [$this->htmlOptionNine(), 'https://example.com/images/favicon.ico', null, Favicon::TYPE_ICON],
+            [$this->htmlOptionTen(), 'https://www.example.com/favicon123.ico', null, Favicon::TYPE_SHORTCUT_ICON],
+            [$this->htmlOptionEleven(), 'https://example.com/android-icon-192x192.png', 192, Favicon::TYPE_ICON],
         ];
     }
 

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -2,9 +2,11 @@
 
 namespace AshAllenDesign\FaviconFetcher\Tests\Feature\Drivers;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Drivers\HttpDriver;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
+use AshAllenDesign\FaviconFetcher\Favicon;
 use AshAllenDesign\FaviconFetcher\FetcherManager;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\CustomDriver;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\NullDriver;
@@ -242,89 +244,143 @@ class HttpDriverTest extends TestCase
         self::assertSame('example.com is not a valid URL', $exception->getMessage());
     }
 
-    public function faviconLinksInHtmlProvider(): array
+    /**
+     * @test
+     *
+     * @dataProvider allFaviconLinksInHtmlProvider
+     */
+    public function all_icons_for_a_url_can_be_fetched(string $html, $expectedFaviconCollection): void
+    {
+        Http::fake([
+            'https://example.com' => Http::response($html),
+            '*' => Http::response('should not hit here'),
+        ]);
+
+        $favicons = (new HttpDriver())->fetchAll('https://example.com');
+
+        self::assertInstanceOf(FaviconCollection::class, $favicons);
+        self::assertCount($expectedFaviconCollection->count(), $favicons);
+
+        // TODO Add extra assertions.
+    }
+
+    /** @test */
+    public function empty_favicon_collection_is_returned_if_no_icons_can_be_found_for_a_url(): void
+    {
+
+    }
+
+    /** @test */
+    public function error_is_thrown_if_trying_to_find_all_the_favicons_for_a_url_that_does_not_exist(): void
+    {
+
+    }
+
+    /** @test */
+    public function all_favicons_for_a_url_can_be_fetched_from_the_cache(): void
+    {
+
+    }
+
+    /** @test */
+    public function all_favicons_for_a_url_can_be_cached(): void
+    {
+
+    }
+
+    public function allFaviconLinksInHtmlProvider(): array
     {
         return [
-            $this->htmlOptionOne(),
-            $this->htmlOptionTwo(),
-            $this->htmlOptionThree(),
-            $this->htmlOptionFour(),
-            $this->htmlOptionFive(),
-            $this->htmlOptionSix(),
-            $this->htmlOptionSeven(),
-            $this->htmlOptionEight(),
-            $this->htmlOptionNine(),
-            $this->htmlOptionTen(),
+            [$this->htmlOptionOne(),
+                new FaviconCollection([
+                    new Favicon('https://example.com', 'https://example.com/icon/is/here.ico')
+                ]),
+            ],
+//            [$this->htmlOptionTwo(), 'https://example.com/icon/is/here.ico'],
+//            [$this->htmlOptionThree(), 'https://example.com/icon/is/here.ico'],
+//            [$this->htmlOptionFour(), 'https://example.com/favicon/favicon-32x32.png'],
+//            [$this->htmlOptionFive(), 'https://example.com/icon/is/here.ico'],
+//            [$this->htmlOptionSix(), 'https://example.com/images/favicon.ico'],
+//            [$this->htmlOptionSeven(), 'https://example.com/images/favicon.ico'],
+//            [$this->htmlOptionEight(), 'https://example.com/images/favicon.ico'],
+//            [$this->htmlOptionNine(), 'https://example.com/images/favicon.ico'],
+//            [$this->htmlOptionTen(), 'https://www.example.com/favicon123.ico'],
+//            [$this->htmlOptionEleven(), 'https://example.com/android-icon-192x192.png'],
         ];
     }
 
-    private function htmlOptionOne(): array
+    public function faviconLinksInHtmlProvider(): array
     {
-        $responseHtml = <<<'HTML'
+        return [
+            [$this->htmlOptionOne(), 'https://example.com/icon/is/here.ico'],
+            [$this->htmlOptionTwo(), 'https://example.com/icon/is/here.ico'],
+            [$this->htmlOptionThree(), 'https://example.com/icon/is/here.ico'],
+            [$this->htmlOptionFour(), 'https://example.com/favicon/favicon-32x32.png'],
+            [$this->htmlOptionFive(), 'https://example.com/icon/is/here.ico'],
+            [$this->htmlOptionSix(), 'https://example.com/images/favicon.ico'],
+            [$this->htmlOptionSeven(), 'https://example.com/images/favicon.ico'],
+            [$this->htmlOptionEight(), 'https://example.com/images/favicon.ico'],
+            [$this->htmlOptionNine(), 'https://example.com/images/favicon.ico'],
+            [$this->htmlOptionTen(), 'https://www.example.com/favicon123.ico'],
+            [$this->htmlOptionEleven(), 'https://example.com/android-icon-192x192.png'],
+        ];
+    }
+
+    private function htmlOptionOne(): string
+    {
+        return <<<'HTML'
             <html lang="en">
                 <link rel="icon" href="icon/is/here.ico" />
             </html>
         HTML;
-
-        return [$responseHtml, 'https://example.com/icon/is/here.ico'];
     }
 
-    private function htmlOptionTwo(): array
+    private function htmlOptionTwo(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <html lang="en">
                 <link rel="icon" href="/icon/is/here.ico" />
             </html>
         HTML;
-
-        return [$responseHtml, 'https://example.com/icon/is/here.ico'];
     }
 
-    private function htmlOptionThree(): array
+    private function htmlOptionThree(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <html lang="en">
                 <link rel="shortcut icon" href="/icon/is/here.ico" />
             </html>
         HTML;
-
-        return [$responseHtml, 'https://example.com/icon/is/here.ico'];
     }
 
-    private function htmlOptionFour(): array
+    private function htmlOptionFour(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <html lang="en">
                 <link rel="icon" type="image/png" href="https://example.com/favicon/favicon-32x32.png"/><link rel="apple-touch-icon" sizes="57x57" href="https://example.com/favicon/apple-icon-57x57.png"/><link rel="apple-touch-icon" sizes="60x60" href="https://example.com/favicon/apple-icon-60x60.png"/><link rel="apple-touch-icon" sizes="72x72" href="https://example.com/favicon/apple-icon-72x72.png"/><link rel="apple-touch-icon" sizes="76x76" href="https://example.com/favicon/apple-icon-72x72.png"/><link rel="apple-touch-icon" sizes="114x114" href="https://example.com/favicon/apple-icon-76x76.png"/><link rel="apple-touch-icon" sizes="120x120" href="https://example.com/favicon/apple-icon-120x120.png"/><link rel="apple-touch-icon" sizes="144x144" href="https://example.com/favicon/apple-icon-144x144.png"/><link rel="apple-touch-icon" sizes="152x152" href="https://example.com/favicon/apple-icon-152x152.png"/><link rel="apple-touch-icon" sizes="180x180" href="https://example.com/favicon/apple-icon-180x180.png"/><link rel="icon" type="image/png" sizes="192x192" href="https://example.com/favicon/android-icon-192x192.png"/>
             </html>
         HTML;
-
-        return [$responseHtml, 'https://example.com/favicon/favicon-32x32.png'];
     }
 
-    private function htmlOptionFive(): array
+    private function htmlOptionFive(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <html lang="en">
                 <link href="/icon/is/here.ico" rel="shortcut icon" />
             </html>
         HTML;
-
-        return [$responseHtml, 'https://example.com/icon/is/here.ico'];
     }
 
-    private function htmlOptionSix(): array
+    private function htmlOptionSix(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <head> <title>Title here</title> <meta name="description" content="Meta description here"> <meta charset="utf-8"> <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> <meta http-equiv="X-UA-Compatible" content="IE=edge"> <link rel="alternate" href="https://www.example.lv" hreflang="lv"> <link rel="alternate" href="https://www.example.lt/" hreflang="lt"> <link rel="alternate" href="https://www.example.ee/" hreflang="ee"> <link rel="alternate" href="https://www.example.ru/" hreflang="ru"> <link rel="alternate" href="https://www.example.com/en/" hreflang="en"> <link rel="alternate" href="https://www.example.com/default" hreflang="x-default"> <meta name="theme-color" content="#FFFFFF"> <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icon-180x180.png"> <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico"> <link rel="stylesheet" href="/css/app.css?id=123"> <script src="/vendor/livewire/livewire.js?id=456" data-turbo-eval="false" data-turbolinks-eval="false" ></script><script data-turbo-eval="false" data-turbolinks-eval="false" >
         HTML;
-
-        return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
 
-    private function htmlOptionSeven(): array
+    private function htmlOptionSeven(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <head>
                 <title>Title here</title>
                 <meta name="description" content="Meta description here">
@@ -345,22 +401,18 @@ class HttpDriverTest extends TestCase
                 <script data-turbo-eval="false" data-turbolinks-eval="false" ></script>
             </head>
         HTML;
-
-        return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
 
-    private function htmlOptionEight(): array
+    private function htmlOptionEight(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <head> <title>Title here</title> <meta name="description" content="Meta description here"> <meta charset="utf-8"> <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"> <meta http-equiv="X-UA-Compatible" content="IE=edge"> <link rel="alternate" href="https://www.example.lv" hreflang="lv"> <link rel="alternate" href="https://www.example.lt/" hreflang="lt"> <link rel="alternate" href="https://www.example.ee/" hreflang="ee"> <link rel="alternate" href="https://www.example.ru/" hreflang="ru"> <link rel="alternate" href="https://www.example.com/en/" hreflang="en"> <link rel="alternate" href="https://www.example.com/default" hreflang="x-default"> <meta name="theme-color" content="#FFFFFF"> <link rel="apple-touch-icon" sizes="180x180" href="/images/apple-icon-180x180.png"> <link rel="icon" type="image/x-icon" href="/images/favicon.ico"> <link rel="stylesheet" href="/css/app.css?id=123"> <script src="/vendor/livewire/livewire.js?id=456" data-turbo-eval="false" data-turbolinks-eval="false" ></script><script data-turbo-eval="false" data-turbolinks-eval="false" >
         HTML;
-
-        return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
 
-    private function htmlOptionNine(): array
+    private function htmlOptionNine(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <head>
                 <title>Title here</title>
                 <meta name="description" content="Meta description here">
@@ -381,13 +433,11 @@ class HttpDriverTest extends TestCase
                 <script data-turbo-eval="false" data-turbolinks-eval="false" ></script>
             </head>
         HTML;
-
-        return [$responseHtml, 'https://example.com/images/favicon.ico'];
     }
 
-    private function htmlOptionTen(): array
+    private function htmlOptionTen(): string
     {
-        $responseHtml = <<<'HTML'
+        return <<<'HTML'
             <head>
                 <title>Test Title</title>
                 <meta content='IE=edge' http-equiv='X-UA-Compatible'>
@@ -397,7 +447,32 @@ class HttpDriverTest extends TestCase
                 <link href='https://www.example.com/favicon123.ico' rel='shortcut icon' type='image/x-icon'>
             </head>
         HTML;
+    }
 
-        return [$responseHtml, 'https://www.example.com/favicon123.ico'];
+    private function htmlOptionEleven(): string
+    {
+        return <<<'HTML'
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <link rel="apple-touch-icon" sizes="57x57" href="/apple-icon-57x57.png">
+                <link rel="apple-touch-icon" sizes="60x60" href="/apple-icon-60x60.png">
+                <link rel="apple-touch-icon" sizes="72x72" href="/apple-icon-72x72.png">
+                <link rel="apple-touch-icon" sizes="76x76" href="/apple-icon-76x76.png">
+                <link rel="apple-touch-icon" sizes="114x114" href="/apple-icon-114x114.png">
+                <link rel="apple-touch-icon" sizes="120x120" href="/apple-icon-120x120.png">
+                <link rel="apple-touch-icon" sizes="144x144" href="/apple-icon-144x144.png">
+                <link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152x152.png">
+                <link rel="apple-touch-icon" sizes="200x200" href="/apple-icon-200x200.png">
+                <link rel="icon" type="image/png" sizes="192x192"  href="/android-icon-192x192.png">
+                <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
+                <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
+                <link rel="manifest" href="/manifest.json">
+                <meta name="msapplication-TileColor" content="#ffffff">
+                <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
+                <meta name="theme-color" content="#ffffff">
+                <title>Dummy title</title>
+            </head>
+        HTML;
     }
 }

--- a/tests/Feature/Drivers/UnavatarDriverTest.php
+++ b/tests/Feature/Drivers/UnavatarDriverTest.php
@@ -5,6 +5,7 @@ namespace AshAllenDesign\FaviconFetcher\Tests\Feature\Drivers;
 use AshAllenDesign\FaviconFetcher\Drivers\UnavatarDriver;
 use AshAllenDesign\FaviconFetcher\Exceptions\FaviconNotFoundException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
+use AshAllenDesign\FaviconFetcher\Favicon;
 use AshAllenDesign\FaviconFetcher\FetcherManager;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\CustomDriver;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\NullDriver;
@@ -40,7 +41,11 @@ class UnavatarDriverTest extends TestCase
     {
         Cache::put(
             'favicon-fetcher.example.com',
-            'url-goes-here',
+            [
+                'favicon_url' => 'url-goes-here',
+                'icon_size' => null,
+                'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+            ],
             now()->addHour()
         );
 

--- a/tests/Feature/FaviconTest.php
+++ b/tests/Feature/FaviconTest.php
@@ -88,7 +88,11 @@ class FaviconTest extends TestCase
         Cache::shouldReceive('put')
             ->withArgs([
                 'favicon-fetcher.example.com',
-                'https://example.com/favicon.ico',
+                [
+                    'favicon_url' => 'https://example.com/favicon.ico',
+                    'icon_size' => null,
+                    'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+                ],
                 Mockery::on(fn(CarbonInterface $ttl): bool => $ttl->is($expectedTtl)),
             ])
             ->once();
@@ -124,7 +128,11 @@ class FaviconTest extends TestCase
         Cache::shouldReceive('put')
             ->withArgs([
                 'favicon-fetcher.example.com',
-                'https://example.com/favicon.ico',
+                [
+                    'favicon_url' => 'https://example.com/favicon.ico',
+                    'icon_size' => null,
+                    'icon_type' => Favicon::TYPE_ICON_UNKNOWN,
+                ],
                 Mockery::on(fn(CarbonInterface $ttl): bool => $ttl->is($expectedTtl)),
             ])
             ->once();

--- a/tests/Feature/FaviconTest.php
+++ b/tests/Feature/FaviconTest.php
@@ -2,6 +2,8 @@
 
 namespace AshAllenDesign\FaviconFetcher\Tests\Feature;
 
+use AshAllenDesign\FaviconFetcher\Exceptions\InvalidIconSizeException;
+use AshAllenDesign\FaviconFetcher\Exceptions\InvalidIconTypeException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Carbon\CarbonInterface;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -20,8 +22,8 @@ class FaviconTest extends TestCase
     public function favicon_url_can_be_returned(): void
     {
         $favicon = new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         );
 
         self::assertSame('https://example.com/favicon.ico', $favicon->getFaviconUrl());
@@ -36,8 +38,8 @@ class FaviconTest extends TestCase
         ]);
 
         $favicon = new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         );
 
         self::assertSame('favicon contents here', $favicon->content());
@@ -47,8 +49,8 @@ class FaviconTest extends TestCase
     public function url_can_be_returned(): void
     {
         $favicon = new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         );
 
         self::assertSame('https://example.com', $favicon->getUrl());
@@ -58,8 +60,8 @@ class FaviconTest extends TestCase
     public function retrieved_from_cache_value_can_be_returned_if_the_favicon_was_retrieved_from_the_cache(): void
     {
         $favicon = Favicon::makeFromCache(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         );
 
         self::assertTrue($favicon->retrievedFromCache());
@@ -69,8 +71,8 @@ class FaviconTest extends TestCase
     public function retrieved_from_cache_value_can_be_returned_if_the_favicon_was_not_retrieved_from_the_cache(): void
     {
         $favicon = new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         );
 
         self::assertFalse($favicon->retrievedFromCache());
@@ -87,13 +89,13 @@ class FaviconTest extends TestCase
             ->withArgs([
                 'favicon-fetcher.example.com',
                 'https://example.com/favicon.ico',
-                Mockery::on(fn (CarbonInterface $ttl): bool => $ttl->is($expectedTtl)),
+                Mockery::on(fn(CarbonInterface $ttl): bool => $ttl->is($expectedTtl)),
             ])
             ->once();
 
         (new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         ))->cache($expectedTtl);
     }
 
@@ -123,7 +125,7 @@ class FaviconTest extends TestCase
             ->withArgs([
                 'favicon-fetcher.example.com',
                 'https://example.com/favicon.ico',
-                Mockery::on(fn (CarbonInterface $ttl): bool => $ttl->is($expectedTtl)),
+                Mockery::on(fn(CarbonInterface $ttl): bool => $ttl->is($expectedTtl)),
             ])
             ->once();
 
@@ -144,8 +146,8 @@ class FaviconTest extends TestCase
         ]);
 
         $favicon = new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         );
 
         $path = $favicon->store('favicons');
@@ -165,8 +167,8 @@ class FaviconTest extends TestCase
         ]);
 
         $favicon = new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.com',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.com',
         );
 
         $path = $favicon->store('favicons');
@@ -186,10 +188,97 @@ class FaviconTest extends TestCase
         ]);
 
         (new Favicon(
-            'https://example.com',
-            'https://example.com/favicon.ico',
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
         ))->storeAs('favicons', 'fetched');
 
         self::assertSame('favicon contents here', Storage::get('favicons/fetched.ico'));
+    }
+
+    public function icon_type_defaults_to_unknown_if_not_explicitly_set(): void
+    {
+        $iconType = (new Favicon(
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
+        ))->getIconType();
+
+        self::assertSame(Favicon::TYPE_ICON_UNKNOWN, $iconType);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider iconTypeProvider
+     */
+    public function icon_type_can_be_set_and_returned(string $expectedIconType): void
+    {
+        $iconType = (new Favicon(
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
+        ))
+            ->setIconType($expectedIconType)
+            ->getIconType();
+
+        self::assertSame($expectedIconType, $iconType);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider iconSizeProvider
+     */
+    public function icon_size_can_be_set_and_returned(?int $expectedIconSize): void
+    {
+        $iconSize = (new Favicon(
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
+        ))
+            ->setIconSize($expectedIconSize)
+            ->getIconSize();
+
+        self::assertSame($expectedIconSize, $iconSize);
+    }
+
+    /** @test */
+    public function exception_is_thrown_when_trying_to_create_a_favicon_with_an_invalid_icon_type(): void
+    {
+        $this->expectException(InvalidIconTypeException::class);
+        $this->expectExceptionMessage('The type [INVALID] is not a valid favicon type.');
+
+        (new Favicon(
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
+        ))->setIconType('INVALID');
+    }
+
+    /** @test */
+    public function exception_is_thrown_when_trying_to_create_a_favicon_with_an_invalid_icon_size(): void
+    {
+        $this->expectException(InvalidIconSizeException::class);
+        $this->expectExceptionMessage('The size [-1] is not a valid favicon size.');
+
+        (new Favicon(
+            url: 'https://example.com',
+            faviconUrl: 'https://example.com/favicon.ico',
+        ))->setIconSize(-1);
+    }
+
+    public function iconTypeProvider(): array
+    {
+        return [
+            [Favicon::TYPE_ICON],
+            [Favicon::TYPE_SHORTCUT_ICON],
+            [Favicon::TYPE_APPLE_TOUCH_ICON],
+            [Favicon::TYPE_ICON_UNKNOWN],
+        ];
+    }
+
+    public function iconSizeProvider(): array
+    {
+        return [
+            [null],
+            [16],
+            [190],
+        ];
     }
 }

--- a/tests/Feature/_data/CustomDriver.php
+++ b/tests/Feature/_data/CustomDriver.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\FaviconFetcher\Tests\Feature\_data;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
 use AshAllenDesign\FaviconFetcher\Favicon;
 
@@ -9,11 +10,20 @@ class CustomDriver implements Fetcher
 {
     public function fetch(string $url): ?Favicon
     {
-        return new Favicon('url-from-default', 'favicon-from-default');
+        return new Favicon(
+            url: 'url-from-default',
+            faviconUrl: 'favicon-from-default',
+            fromDriver: $this,
+        );
     }
 
     public function fetchOr(string $url, mixed $default): mixed
     {
         return 'default';
+    }
+
+    public function fetchAll(string $url): FaviconCollection
+    {
+        // TODO: Implement fetchAll() method.
     }
 }

--- a/tests/Feature/_data/NullDriver.php
+++ b/tests/Feature/_data/NullDriver.php
@@ -2,6 +2,7 @@
 
 namespace AshAllenDesign\FaviconFetcher\Tests\Feature\_data;
 
+use AshAllenDesign\FaviconFetcher\Collections\FaviconCollection;
 use AshAllenDesign\FaviconFetcher\Contracts\Fetcher;
 use AshAllenDesign\FaviconFetcher\Favicon;
 
@@ -19,5 +20,10 @@ class NullDriver implements Fetcher
     public function fetchOr(string $url, mixed $default): mixed
     {
         return 'default';
+    }
+
+    public function fetchAll(string $url): FaviconCollection
+    {
+        // TODO: Implement fetchAll() method.
     }
 }


### PR DESCRIPTION
This PR started off with adding the functionality to get all the different sizes of icons that a URL has. However, it's ended up changing into a PR that grabs the type and size of the icons when fetching a single icon.

I feel like this branch is starting to get a bit big and messy, so I'm merging this in. I'll focus on finishing the `fetchAll` functionality in another PR.