### PR TITLE
Strip the path from relative URLs

### DIFF
--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -318,8 +318,12 @@ class HttpDriver implements Fetcher
      */
     private function convertToAbsoluteUrl(string $baseUrl, string $faviconUrl): string
     {
+        // If the favicon URL is relative, we need to convert it to be absolute.
+        // We also strip the path (if there is one) from the base URL.
         if (! filter_var($faviconUrl, FILTER_VALIDATE_URL)) {
-            $faviconUrl = $baseUrl.'/'.ltrim($faviconUrl, '/');
+            $parsedUrl = parse_url($baseUrl);
+
+            $faviconUrl = $parsedUrl['scheme'].'://'.$parsedUrl['host'].'/'.ltrim($faviconUrl, '/');
         }
 
         return $faviconUrl;

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -44,6 +44,20 @@ class HttpDriverTest extends TestCase
     }
 
     /** @test */
+    public function favicon_can_be_fetched_if_the_url_has_a_path_and_thelink_element_contains_a_relative_url(): void
+    {
+        Http::fake([
+            'https://example.com/blog' => Http::response($this->htmlOptionOne()),
+            'https://example.com/icon/is/here.ico' => Http::response('favicon contents here'),
+            '*' => Http::response('should not hit here'),
+        ]);
+
+        $favicon = (new HttpDriver())->fetch('https://example.com/blog');
+
+        self::assertSame('https://example.com/icon/is/here.ico', $favicon->getFaviconUrl());
+    }
+
+    /** @test */
     public function favicon_can_be_fetched_from_guessed_url_if_it_cannot_be_found_in_response_html(): void
     {
         $responseHtml = <<<'HTML'


### PR DESCRIPTION
This PR strips the path from the URLs if a favicon URL is relative.

Say `example.com` has their favicon available at `example.com/favicon.ico` by specifying it in their HTML like so:

```html
<link rel="icon" href="favicon.ico" />
```

Now let's say we use `Favicon::driver('http')->fetch('https://example.com/blog')`. Previously, this would have returned `https://example.com/blog/favicon.ico` because we were just concatenating the website URL and the favicon's relative path.

This PR will strip the path from the URL, so it will return `https://example.com/favicon.ico` instead 🙂