### PR TITLE
keep port if available

### DIFF
--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -339,11 +339,23 @@ class HttpDriver implements Fetcher
         return rtrim($this->stripPathFromUrl($url)).'/favicon.ico';
     }
 
+    /**
+     * Strip the path and any query parameters from the given URL so that
+     * we only return the scheme, host and port (if there is one).
+     *
+     * @param string $url
+     * @return string
+     */
     private function stripPathFromUrl(string $url): string
     {
         $parsedUrl = parse_url($url);
-        $port = array_key_exists('port', $parsedUrl) ? ':'.$parsedUrl['port'] : '';
 
-        return $parsedUrl['scheme'].'://'.$parsedUrl['host'].$port;
+        $url = $parsedUrl['scheme'].'://'.$parsedUrl['host'];
+
+        if (array_key_exists('port', $parsedUrl)) {
+            $url .= ':'.$parsedUrl['port'];
+        }
+
+        return $url;
     }
 }

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -343,7 +343,7 @@ class HttpDriver implements Fetcher
      * Strip the path and any query parameters from the given URL so that
      * we only return the scheme, host and port (if there is one).
      *
-     * @param string $url
+     * @param  string  $url
      * @return string
      */
     private function stripPathFromUrl(string $url): string

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -342,7 +342,8 @@ class HttpDriver implements Fetcher
     private function stripPathFromUrl(string $url): string
     {
         $parsedUrl = parse_url($url);
+        $port = array_key_exists('port', $parsedUrl) ? ':'.$parsedUrl['port'] : '';
 
-        return $parsedUrl['scheme'].'://'.$parsedUrl['host'];
+        return $parsedUrl['scheme'].'://'.$parsedUrl['host'].$port;
     }
 }

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -130,6 +130,19 @@ class HttpDriverTest extends TestCase
     }
 
     /** @test */
+    public function favicon_can_be_fetched_from_url_with_query_parameters(): void
+    {
+        Http::fake([
+            'http://example.com?query=parameter' => Http::response('<link href="/icon/favicon.ico" rel="icon">'),
+            '*' => Http::response('should not hit here'),
+        ]);
+
+        $favicon = (new HttpDriver())->fetch('http://example.com?query=parameter');
+
+        self::assertSame('http://example.com/icon/favicon.ico', $favicon->getFaviconUrl());
+    }
+
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -117,6 +117,19 @@ class HttpDriverTest extends TestCase
     }
 
     /** @test */
+    public function favicon_can_be_fetched_from_url_with_port(): void
+    {
+        Http::fake([
+            'http://example.com:8080' => Http::response('<link href="/icon/favicon.ico" rel="icon">'),
+            '*' => Http::response('should not hit here'),
+        ]);
+
+        $favicon = (new HttpDriver())->fetch('http://example.com:8080');
+
+        self::assertSame('http://example.com:8080/icon/favicon.ico', $favicon->getFaviconUrl());
+    }
+
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(


### PR DESCRIPTION
I have some Docker services running on a host that use different ports. To get the favicon from all services, the fetcher needs to keep the specified port for all URLs.

BTW: This is my very first contribution to a repo ever. :) 