### PR TITLE
Migrate to `symfony/dom-crawler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-**v2.0.0 (released 2023-03-XX):**
+**v2.0.0 (released 2023-03-23):**
 - Added driver for the [Favicon Grabber API](https://favicongrabber.com/). ([#24](https://github.com/ash-jc-allen/favicon-fetcher/pull/24))
 - Added `fetchAll` implementation to the `HttpDriver` for fetching all the icons for a URL. ([#29](https://github.com/ash-jc-allen/favicon-fetcher/pull/29), [#31](https://github.com/ash-jc-allen/favicon-fetcher/pull/31))
 - Added `fetchAll` method to the `AshAllenDesign\FaviconFetcher\Contracts\Fetcher` interface. ([#29](https://github.com/ash-jc-allen/favicon-fetcher/pull/29))

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "illuminate/cache": "^8.0|^9.0|^10.0",
     "illuminate/filesystem": "^8.0|^9.0|^10.0",
     "illuminate/http": "^8.0|^9.0|^10.0",
-    "guzzlehttp/guzzle": "^7.4"
+    "guzzlehttp/guzzle": "^7.4",
+    "symfony/dom-crawler": "^6.3"
   },
   "require-dev": {
     "mockery/mockery": "^1.0",

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -17,9 +17,6 @@ use AshAllenDesign\FaviconFetcher\Exceptions\InvalidIconTypeException;
 use AshAllenDesign\FaviconFetcher\Exceptions\InvalidUrlException;
 use AshAllenDesign\FaviconFetcher\Favicon;
 use Illuminate\Http\Client\Response;
-use Illuminate\Support\Collection;
-use Illuminate\Support\Str;
-use Illuminate\Support\Facades\Http;
 use Symfony\Component\DomCrawler\Crawler;
 
 class HttpDriver implements Fetcher

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -73,7 +73,7 @@ class HttpDriver implements Fetcher
                 throw new FaviconNotFoundException('A favicon cannot be found for '.$url);
             }
 
-            return new FaviconCollection();
+            $favicons = new FaviconCollection();
         }
 
         if ($favicons->isEmpty()) {

--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -162,6 +162,10 @@ class HttpDriver implements Fetcher
                 head link[rel="apple-touch-icon"]
             ');
 
+        if (!$linkTags->count()) {
+            return null;
+        }
+
         $favicons = $linkTags->each(function (Crawler $linkTag) use ($url): Favicon {
             $favicon = new Favicon(
                 $url,

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -675,6 +675,7 @@ class HttpDriverTest extends TestCase
             [$this->htmlOptionNine(), 'https://example.com/images/favicon.ico', null, Favicon::TYPE_ICON],
             [$this->htmlOptionTen(), 'https://www.example.com/favicon123.ico', null, Favicon::TYPE_SHORTCUT_ICON],
             [$this->htmlOptionEleven(), 'https://example.com/android-icon-192x192.png', 192, Favicon::TYPE_ICON],
+            [$this->htmlOptionTwelve(), 'https://example.com/android-icon-192x192.png', 192, Favicon::TYPE_ICON],
         ];
     }
 
@@ -819,6 +820,33 @@ class HttpDriverTest extends TestCase
                 <link rel="icon" type="image/png" sizes="192x192"  href="/android-icon-192x192.png">
                 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
                 <link rel="icon" type="image/png" sizes="96x96" href="/favicon-96x96.png">
+                <link rel="manifest" href="/manifest.json">
+                <meta name="msapplication-TileColor" content="#ffffff">
+                <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
+                <meta name="theme-color" content="#ffffff">
+                <title>Dummy title</title>
+            </head>
+        HTML;
+    }
+
+    private function htmlOptionTwelve(): string
+    {
+        return <<<'HTML'
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <link rel="apple-touch-icon" sizes="57x57" href=/apple-icon-57x57.png>
+                <link rel=apple-touch-icon sizes=60x60 href=/apple-icon-60x60.png>
+                <link rel="apple-touch-icon" sizes="72x72" href=/apple-icon-72x72.png>
+                <link rel="apple-touch-icon" sizes="76x76" href=/apple-icon-76x76.png>
+                <link rel="apple-touch-icon" sizes="114x114" href=/apple-icon-114x114.png>
+                <link rel="apple-touch-icon" sizes="120x120" href=/apple-icon-120x120.png>
+                <link rel="apple-touch-icon" sizes="144x144" href=/apple-icon-144x144.png>
+                <link rel="apple-touch-icon" sizes="152x152" href=/apple-icon-152x152.png>
+                <link rel="apple-touch-icon" sizes="200x200" href=/apple-icon-200x200.png>
+                <link rel="icon" type="image/png" sizes="192x192"  href=/android-icon-192x192.png>
+                <link rel="icon" type="image/png" sizes="32x32" href=/favicon-32x32.png>
+                <link rel="icon" type="image/png" sizes="96x96" href=/favicon-96x96.png>
                 <link rel="manifest" href="/manifest.json">
                 <meta name="msapplication-TileColor" content="#ffffff">
                 <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -385,6 +385,7 @@ class HttpDriverTest extends TestCase
     {
         Http::fake([
             'https://example.com' => Http::response('not found', 404),
+            'https://example.com/favicon.ico' => Http::response('not found', 404),
             '*' => Http::response('should not hit here'),
         ]);
 

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -433,6 +433,34 @@ class HttpDriverTest extends TestCase
     }
 
     /** @test */
+    public function error_is_thrown_if_no_icons_can_be_found_for_a_url_and_the_throw_on_not_found_flag_is_true(): void
+    {
+        $responseHtml = <<<'HTML'
+            <html lang="en">
+                <link rel="localization" href="branding/brand.ftl" />
+            </html>
+        HTML;
+
+        Http::fake([
+            'https://example.com' => Http::response($responseHtml),
+            '*' => Http::response('should not hit here'),
+        ]);
+
+        $exception = null;
+
+        try {
+            (new HttpDriver())
+                ->throw()
+                ->fetchAll('https://example.com');
+        } catch (\Exception $e) {
+            $exception = $e;
+        }
+
+        self::assertInstanceOf(FaviconNotFoundException::class, $exception);
+        self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
+    }
+
+    /** @test */
     public function all_favicon_for_a_url_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(


### PR DESCRIPTION
Up until now, the `HttpDriver` has used some regex and pattern-matching that I wrote myself to try and extract the links from the HTML. They've worked most of the time, but it's starting to become a bit more difficult to catch every use case.

This PR proposes requiring `symfony/dom-crawler` and using that to grab the favicons when using the `HttpDriver`. In theory, any devs using Favicon Fetcher shouldn't notice any difference.

I'll be checking this over the next day or two to make sure the migration will go as smoothly as possible 😄