### PR TITLE
Fix #74 - Returns null when link icon tag doesn't have a href.

### DIFF
--- a/src/Drivers/HttpDriver.php
+++ b/src/Drivers/HttpDriver.php
@@ -142,6 +142,10 @@ class HttpDriver implements Fetcher
             return null;
         }
 
+        if ($linkTag->attr('href') === null) {
+            return null;
+        }
+
         $favicon = new Favicon(
             url: $url,
             faviconUrl: $this->convertToAbsoluteUrl($url, $linkTag->attr('href')),


### PR DESCRIPTION
Returns null instead of attempting to read something that isn't there. Works fine with the provided URL given in the issue #74. 