### PR TITLE
Add support for Larastan 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "mockery/mockery": "^1.0",
     "orchestra/testbench": "^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^9.0|^10.0|^11.0",
-    "nunomaduro/larastan": "^2.0"
+    "larastan/larastan": "^2.0"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "mockery/mockery": "^1.0",
     "orchestra/testbench": "^7.0|^8.0|^9.0",
     "phpunit/phpunit": "^9.0|^10.0|^11.0",
-    "larastan/larastan": "^2.0"
+    "larastan/larastan": "^2.0|^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 includes:
-    - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/larastan/larastan/extension.neon
 
 parameters:
 

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,4 +13,3 @@ parameters:
         - '#^Call to an undefined method AshAllenDesign\\FaviconFetcher\\Collections\\FaviconCollection::fetch\(\)#'
         - '#^Call to an undefined method AshAllenDesign\\FaviconFetcher\\Collections\\FaviconCollection::fetchAll\(\)#'
 
-    checkMissingIterableValueType: false

--- a/src/Concerns/HasDefaultFunctionality.php
+++ b/src/Concerns/HasDefaultFunctionality.php
@@ -21,7 +21,7 @@ trait HasDefaultFunctionality
      * An array of the drivers that should be as fallbacks if the current
      * driver fails to retrieve a favicon for the given URL.
      *
-     * @var array
+     * @var string[]
      */
     protected array $fallbacks = [];
 

--- a/src/Facades/Favicon.php
+++ b/src/Facades/Favicon.php
@@ -30,8 +30,6 @@ class Favicon extends Facade
      * Get the registered name of the component.
      *
      * @return string
-     *
-     * @throws RuntimeException
      */
     protected static function getFacadeAccessor(): string
     {

--- a/src/Favicon.php
+++ b/src/Favicon.php
@@ -246,7 +246,7 @@ class Favicon
     /**
      * Transform the favicon object into an array that can be cached.
      *
-     * @return array
+     * @return array<string,string|int|null>
      */
     public function toCache(): array
     {

--- a/src/FetcherManager.php
+++ b/src/FetcherManager.php
@@ -14,6 +14,9 @@ use AshAllenDesign\FaviconFetcher\Exceptions\FaviconFetcherException;
 
 class FetcherManager
 {
+    /**
+     * @var Fetcher[]
+     */
     protected static array $customDrivers = [];
 
     public static function driver(?string $driver = null): Fetcher


### PR DESCRIPTION
This PR switches out `nunomaduro/larastan` for `larastan/larastan`. I've also added support for Larastan 3 at the same time 🙂