### PR TITLE
Revert "PHPUnit 10 Shift"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .idea/
 vendor/
 composer.lock
-/.phpunit.cache
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "AshAllenDesign\\FaviconFetcher\\Tests\\": "tests/"
+        "AshAllenDesign\\FaviconFetcher\\Tests\\": "tests/"
     }
   },
   "extra": {

--- a/tests/Feature/Collections/FaviconCollectionTest.php
+++ b/tests/Feature/Collections/FaviconCollectionTest.php
@@ -9,13 +9,12 @@ use AshAllenDesign\FaviconFetcher\Favicon;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
-use PHPUnit\Framework\Attributes\Test;
 
 final class FaviconCollectionTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
+    /** @test */
     public function favicon_collection_can_be_cached_if_the_collection_was_not_retrieved_from_the_cache(): void
     {
         $collection = FaviconCollection::make([
@@ -44,7 +43,7 @@ final class FaviconCollectionTest extends TestCase
         );
     }
 
-    #[Test]
+    /** @test */
     public function favicon_collection_can_be_cached_if_the_collection_was_retrieved_from_the_cache_and_the_force_flag_is_true(): void
     {
         Cache::put(
@@ -76,7 +75,7 @@ final class FaviconCollectionTest extends TestCase
         );
     }
 
-    #[Test]
+    /** @test */
     public function favicon_collection_is_not_cached_if_the_collection_was_retrieved_from_the_cache_and_the_force_flag_is_false(): void
     {
         Cache::put(
@@ -97,7 +96,7 @@ final class FaviconCollectionTest extends TestCase
         );
     }
 
-    #[Test]
+    /** @test */
     public function favicon_collection_is_not_cached_if_the_collection_is_empty(): void
     {
         Cache::shouldReceive('put')->never();
@@ -107,7 +106,7 @@ final class FaviconCollectionTest extends TestCase
         $collection->cache(now()->addDay());
     }
 
-    #[Test]
+    /** @test */
     public function largest_favicon_can_be_retrieved(): void
     {
         $largest = FaviconCollection::make([
@@ -127,7 +126,7 @@ final class FaviconCollectionTest extends TestCase
         self::assertSame('https://example.com/favicon/android-icon-192x192.png', $largest->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function largest_favicon_can_be_retrieved_if_there_are_only_null_sizes(): void
     {
         $largest = FaviconCollection::make([
@@ -138,8 +137,8 @@ final class FaviconCollectionTest extends TestCase
         self::assertSame('https://example.com/favicon/favicon-32x32.png', $largest->getFaviconUrl());
     }
 
-    #[Test]
-    public function largest_favicon_can_be_retrieved_based_on_file_size(): void
+    /** @test */
+    public function largest_favicon_can_be_retrieved_based_on_file_size()
     {
         // mock the favicons to specify file content lengths
         $favicon1 = $this->createMock(Favicon::class);

--- a/tests/Feature/Concerns/MakesHttpRequests/HttpClientTest.php
+++ b/tests/Feature/Concerns/MakesHttpRequests/HttpClientTest.php
@@ -6,13 +6,12 @@ namespace AshAllenDesign\FaviconFetcher\Tests\Feature\Concerns\MakesHttpRequests
 
 use AshAllenDesign\FaviconFetcher\Concerns\MakesHttpRequests;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
-use PHPUnit\Framework\Attributes\Test;
 
 final class HttpClientTest extends TestCase
 {
     use MakesHttpRequests;
 
-    #[Test]
+    /** @test */
     public function http_client_is_returned_with_correct_options(): void
     {
         config([
@@ -28,7 +27,7 @@ final class HttpClientTest extends TestCase
         self::assertFalse($client->getOptions()['verify']);
     }
 
-    #[Test]
+    /** @test */
     public function http_client_is_returned_with_correct_verify_tls_option(): void
     {
         config([

--- a/tests/Feature/Concerns/MakesHttpRequests/WithRequestExceptionHandlingTest.php
+++ b/tests/Feature/Concerns/MakesHttpRequests/WithRequestExceptionHandlingTest.php
@@ -8,13 +8,12 @@ use AshAllenDesign\FaviconFetcher\Concerns\MakesHttpRequests;
 use AshAllenDesign\FaviconFetcher\Exceptions\ConnectionException;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Http\Client\ConnectionException as ClientConnectionException;
-use PHPUnit\Framework\Attributes\Test;
 
 final class WithRequestExceptionHandlingTest extends TestCase
 {
     use MakesHttpRequests;
 
-    #[Test]
+    /** @test */
     public function exception_is_handled_and_rethrown(): void
     {
         $this->expectException(ConnectionException::class);

--- a/tests/Feature/Drivers/DuckDuckGoDriverTest.php
+++ b/tests/Feature/Drivers/DuckDuckGoDriverTest.php
@@ -15,16 +15,17 @@ use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestWith;
 
-final class DuckDuckGoDriverTest extends TestCase
+class DuckDuckGoDriverTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
-    #[TestWith(['https'])]
-    #[TestWith(['http'])]
+    /**
+     * @test
+     *
+     * @testWith ["https"]
+     *           ["http"]
+     */
     public function favicon_can_be_fetched_from_driver(string $protocol): void
     {
         Http::fake([
@@ -37,7 +38,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('https://icons.duckduckgo.com/ip3/example.com.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -59,7 +60,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('url-goes-here', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_is_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -78,7 +79,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('https://icons.duckduckgo.com/ip3/example.com.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -91,7 +92,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function fallback_is_attempted_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -109,7 +110,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('favicon-from-default', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_cannot_find_the_favicon_and_the_throw_on_not_found_flag_is_true(): void
     {
         Http::fake([
@@ -132,7 +133,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method(): void
     {
         Http::fake([
@@ -147,7 +148,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -163,7 +164,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function exception_can_be_thrown_after_attempting_a_fallback(): void
     {
         Http::fake([
@@ -190,7 +191,7 @@ final class DuckDuckGoDriverTest extends TestCase
         self::assertTrue(NullDriver::$flag);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_url_is_invalid(): void
     {
         Http::fake([

--- a/tests/Feature/Drivers/FaviconGrabberDriverTest.php
+++ b/tests/Feature/Drivers/FaviconGrabberDriverTest.php
@@ -15,16 +15,17 @@ use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestWith;
 
-final class FaviconGrabberDriverTest extends TestCase
+class FaviconGrabberDriverTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
-    #[TestWith(['https'])]
-    #[TestWith(['http'])]
+    /**
+     * @test
+     *
+     * @testWith ["https"]
+     *           ["http"]
+     */
     public function favicon_can_be_fetched_from_driver(string $protocol): void
     {
         Http::fake([
@@ -37,7 +38,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -59,7 +60,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('url-goes-here', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_is_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -78,7 +79,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('https://a0.awsstatic.com/libra-css/images/site/fav/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -91,7 +92,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_domain_is_invalid(): void
     {
         Http::fake([
@@ -104,7 +105,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function fallback_is_attempted_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -122,7 +123,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('favicon-from-default', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_cannot_find_the_favicon_and_the_throw_on_not_found_flag_is_true(): void
     {
         Http::fake([
@@ -145,7 +146,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://invalid.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method(): void
     {
         Http::fake([
@@ -160,7 +161,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -176,7 +177,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function exception_can_be_thrown_after_attempting_a_fallback(): void
     {
         Http::fake([
@@ -203,7 +204,7 @@ final class FaviconGrabberDriverTest extends TestCase
         self::assertTrue(NullDriver::$flag);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_url_is_invalid(): void
     {
         Http::fake([

--- a/tests/Feature/Drivers/FaviconKitDriverTest.php
+++ b/tests/Feature/Drivers/FaviconKitDriverTest.php
@@ -15,16 +15,17 @@ use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestWith;
 
-final class FaviconKitDriverTest extends TestCase
+class FaviconKitDriverTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
-    #[TestWith(['https'])]
-    #[TestWith(['http'])]
+    /**
+     * @test
+     *
+     * @testWith ["https"]
+     *           ["http"]
+     */
     public function favicon_can_be_fetched_from_driver(string $protocol): void
     {
         Http::fake([
@@ -37,7 +38,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('https://api.faviconkit.com/example.com', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -59,7 +60,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('url-goes-here', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_is_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -78,7 +79,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('https://api.faviconkit.com/example.com', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -91,7 +92,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function fallback_is_attempted_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -109,7 +110,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('favicon-from-default', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_cannot_find_the_favicon_and_the_throw_on_not_found_flag_is_true(): void
     {
         Http::fake([
@@ -132,7 +133,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method(): void
     {
         Http::fake([
@@ -147,7 +148,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -163,7 +164,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function exception_can_be_thrown_after_attempting_a_fallback(): void
     {
         Http::fake([
@@ -190,7 +191,7 @@ final class FaviconKitDriverTest extends TestCase
         self::assertTrue(NullDriver::$flag);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_url_is_invalid(): void
     {
         Http::fake([

--- a/tests/Feature/Drivers/GoogleSharedStuffDriverTest.php
+++ b/tests/Feature/Drivers/GoogleSharedStuffDriverTest.php
@@ -15,16 +15,17 @@ use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestWith;
 
-final class GoogleSharedStuffDriverTest extends TestCase
+class GoogleSharedStuffDriverTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
-    #[TestWith(['https'])]
-    #[TestWith(['http'])]
+    /**
+     * @test
+     *
+     * @testWith ["https"]
+     *           ["http"]
+     */
     public function favicon_can_be_fetched_from_driver(string $protocol): void
     {
         Http::fake([
@@ -37,7 +38,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('https://www.google.com/s2/favicons?domain='.$protocol.'://example.com', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -59,7 +60,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('url-goes-here', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_is_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -78,7 +79,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('https://www.google.com/s2/favicons?domain=https://example.com', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -91,7 +92,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function fallback_is_attempted_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -109,7 +110,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('favicon-from-default', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_cannot_find_the_favicon_and_the_throw_on_not_found_flag_is_true(): void
     {
         Http::fake([
@@ -132,7 +133,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method(): void
     {
         Http::fake([
@@ -147,7 +148,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -163,7 +164,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function exception_can_be_thrown_after_attempting_a_fallback(): void
     {
         Http::fake([
@@ -190,7 +191,7 @@ final class GoogleSharedStuffDriverTest extends TestCase
         self::assertTrue(NullDriver::$flag);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_url_is_invalid(): void
     {
         Http::fake([

--- a/tests/Feature/Drivers/HttpDriverTest.php
+++ b/tests/Feature/Drivers/HttpDriverTest.php
@@ -17,16 +17,16 @@ use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Http\Client\Request;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestWith;
 
-final class HttpDriverTest extends TestCase
+class HttpDriverTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
-    #[DataProvider('faviconLinksInHtmlProvider')]
+    /**
+     * @test
+     *
+     * @dataProvider faviconLinksInHtmlProvider
+     */
     public function favicon_can_be_fetched_using_link_element_in_html(
         string $html,
         string $expectedFaviconUrl,
@@ -47,7 +47,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame($expectedType, $favicon->getIconType());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_if_the_url_has_a_path_and_thelink_element_contains_a_relative_url(): void
     {
         Http::fake([
@@ -61,7 +61,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('https://example.com/icon/is/here.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_guessed_url_if_it_cannot_be_found_in_response_html(): void
     {
         $responseHtml = <<<'HTML'
@@ -81,7 +81,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('https://example.com/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_guessed_url_if_it_cannot_be_found_in_response_html_and_a_relative_url_is_passed(): void
     {
         $responseHtml = <<<'HTML'
@@ -101,9 +101,12 @@ final class HttpDriverTest extends TestCase
         self::assertSame('https://example.com/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
-    #[TestWith(['https'])]
-    #[TestWith(['http'])]
+    /**
+     * @test
+     *
+     * @testWith ["https"]
+     *           ["http"]
+     */
     public function favicon_can_be_fetched_from_driver(string $protocol): void
     {
         Http::fake([
@@ -117,7 +120,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame($protocol.'://example.com/icon/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_url_with_port(): void
     {
         Http::fake([
@@ -130,7 +133,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('http://example.com:8080/icon/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_url_with_query_parameters(): void
     {
         Http::fake([
@@ -143,7 +146,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('http://example.com/icon/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -167,7 +170,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame(Favicon::TYPE_ICON_UNKNOWN, $favicon->getIconType());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists_in_the_old_string_format(): void
     {
         Cache::put(
@@ -187,7 +190,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame(Favicon::TYPE_ICON_UNKNOWN, $favicon->getIconType());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_is_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -206,7 +209,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('https://example.com/icon/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -219,7 +222,7 @@ final class HttpDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function fallback_is_attempted_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -237,7 +240,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('favicon-from-default', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_cannot_find_the_favicon_and_the_throw_on_not_found_flag_is_true(): void
     {
         Http::fake([
@@ -260,7 +263,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method(): void
     {
         Http::fake([
@@ -275,7 +278,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -291,7 +294,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function exception_can_be_thrown_after_attempting_a_fallback(): void
     {
         Http::fake([
@@ -318,7 +321,7 @@ final class HttpDriverTest extends TestCase
         self::assertTrue(NullDriver::$flag);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_url_is_invalid(): void
     {
         Http::fake([
@@ -337,8 +340,11 @@ final class HttpDriverTest extends TestCase
         self::assertSame('example.com is not a valid URL', $exception->getMessage());
     }
 
-    #[Test]
-    #[DataProvider('allFaviconLinksInHtmlProvider')]
+    /**
+     * @test
+     *
+     * @dataProvider allFaviconLinksInHtmlProvider
+     */
     public function all_icons_for_a_url_can_be_fetched(string $html, $expectedFaviconCollection): void
     {
         Http::fake([
@@ -357,7 +363,7 @@ final class HttpDriverTest extends TestCase
         }
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_guessed_url_if_it_cannot_be_found_in_response_html_when_trying_to_get_all_icons(): void
     {
         $responseHtml = <<<'HTML'
@@ -378,7 +384,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame($favicons->first()->getFaviconUrl(), 'https://example.com/favicon.ico');
     }
 
-    #[Test]
+    /** @test */
     public function empty_favicon_collection_is_returned_if_the_url_cannot_be_reached(): void
     {
         Http::fake([
@@ -392,7 +398,7 @@ final class HttpDriverTest extends TestCase
         self::assertCount(0, $favicons);
     }
 
-    #[Test]
+    /** @test */
     public function empty_favicon_collection_is_returned_if_no_icons_can_be_found_for_a_url(): void
     {
         $responseHtml = <<<'HTML'
@@ -412,7 +418,7 @@ final class HttpDriverTest extends TestCase
         self::assertCount(0, $favicons);
     }
 
-    #[Test]
+    /** @test */
     public function error_is_thrown_if_trying_to_find_all_the_favicons_for_an_invalid_url(): void
     {
         Http::fake([
@@ -431,7 +437,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('example.com is not a valid URL', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function error_is_thrown_if_no_icons_can_be_found_for_a_url_and_the_throw_on_not_found_flag_is_true(): void
     {
         $responseHtml = <<<'HTML'
@@ -459,7 +465,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function all_favicon_for_a_url_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -505,7 +511,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame(Favicon::TYPE_APPLE_TOUCH_ICON, $favicons->skip(2)->first()->getIconType());
     }
 
-    #[Test]
+    /** @test */
     public function all_favicons_for_a_url_are_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -542,7 +548,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('https://example.com/icon/favicon.ico', $favicons->first()->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicons_can_be_returned_using_the_fetchAllOr_method(): void
     {
         Http::fake([
@@ -559,7 +565,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame(null, $favicons->first()->getIconSize());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchAllOr_method(): void
     {
         Http::fake([
@@ -574,7 +580,7 @@ final class HttpDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchAllOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -590,8 +596,8 @@ final class HttpDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
-    public function can_set_the_user_agent_when_fetching(): void
+    /** @test */
+    public function can_set_the_user_agent_when_fetching()
     {
         Http::fake();
 
@@ -614,7 +620,7 @@ final class HttpDriverTest extends TestCase
         });
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_using_fetch_and_the_link_has_no_href(): void
     {
         $responseHtml = <<<'HTML'
@@ -639,7 +645,7 @@ final class HttpDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_using_fetchAll_and_the_link_has_no_href(): void
     {
         $responseHtml = <<<'HTML'

--- a/tests/Feature/Drivers/UnavatarDriverTest.php
+++ b/tests/Feature/Drivers/UnavatarDriverTest.php
@@ -15,16 +15,17 @@ use AshAllenDesign\FaviconFetcher\Tests\Feature\TestCase;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
-use PHPUnit\Framework\Attributes\Test;
-use PHPUnit\Framework\Attributes\TestWith;
 
-final class UnavatarDriverTest extends TestCase
+class UnavatarDriverTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
-    #[TestWith(['https'])]
-    #[TestWith(['http'])]
+    /**
+     * @test
+     *
+     * @testWith ["https"]
+     *           ["http"]
+     */
     public function favicon_can_be_fetched_from_driver(string $protocol): void
     {
         Http::fake([
@@ -37,7 +38,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('https://unavatar.io/example.com?fallback=false', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_fetched_from_the_cache_if_it_already_exists(): void
     {
         Cache::put(
@@ -59,7 +60,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('url-goes-here', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_is_not_fetched_from_the_cache_if_it_exists_but_the_use_cache_flag_is_false(): void
     {
         Cache::put(
@@ -78,7 +79,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('https://unavatar.io/example.com?fallback=false', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function null_is_returned_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -91,7 +92,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertNull($favicon);
     }
 
-    #[Test]
+    /** @test */
     public function fallback_is_attempted_if_the_driver_cannot_find_the_favicon(): void
     {
         Http::fake([
@@ -109,7 +110,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('favicon-from-default', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_cannot_find_the_favicon_and_the_throw_on_not_found_flag_is_true(): void
     {
         Http::fake([
@@ -132,7 +133,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('A favicon cannot be found for https://example.com', $exception->getMessage());
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method(): void
     {
         Http::fake([
@@ -147,7 +148,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function default_value_can_be_returned_using_fetchOr_method_with_a_closure(): void
     {
         Http::fake([
@@ -163,7 +164,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertSame('fallback-to-this', $favicon);
     }
 
-    #[Test]
+    /** @test */
     public function exception_can_be_thrown_after_attempting_a_fallback(): void
     {
         Http::fake([
@@ -190,7 +191,7 @@ final class UnavatarDriverTest extends TestCase
         self::assertTrue(NullDriver::$flag);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_url_is_invalid(): void
     {
         Http::fake([

--- a/tests/Feature/FaviconTest.php
+++ b/tests/Feature/FaviconTest.php
@@ -15,14 +15,12 @@ use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Mockery;
-use PHPUnit\Framework\Attributes\DataProvider;
-use PHPUnit\Framework\Attributes\Test;
 
-final class FaviconTest extends TestCase
+class FaviconTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
+    /** @test */
     public function favicon_url_can_be_returned(): void
     {
         $favicon = new Favicon(
@@ -33,7 +31,7 @@ final class FaviconTest extends TestCase
         self::assertSame('https://example.com/favicon.ico', $favicon->getFaviconUrl());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_contents_can_be_returned(): void
     {
         Http::fake([
@@ -49,7 +47,7 @@ final class FaviconTest extends TestCase
         self::assertSame('favicon contents here', $favicon->content());
     }
 
-    #[Test]
+    /** @test */
     public function url_can_be_returned(): void
     {
         $favicon = new Favicon(
@@ -60,7 +58,7 @@ final class FaviconTest extends TestCase
         self::assertSame('https://example.com', $favicon->getUrl());
     }
 
-    #[Test]
+    /** @test */
     public function retrieved_from_cache_value_can_be_returned_if_the_favicon_was_retrieved_from_the_cache(): void
     {
         $favicon = new Favicon(
@@ -72,7 +70,7 @@ final class FaviconTest extends TestCase
         self::assertTrue($favicon->retrievedFromCache());
     }
 
-    #[Test]
+    /** @test */
     public function retrieved_from_cache_value_can_be_returned_if_the_favicon_was_not_retrieved_from_the_cache(): void
     {
         $favicon = new Favicon(
@@ -83,7 +81,7 @@ final class FaviconTest extends TestCase
         self::assertFalse($favicon->retrievedFromCache());
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_cached_if_it_is_not_already_cached(): void
     {
         Carbon::setTestNow(now());
@@ -108,7 +106,7 @@ final class FaviconTest extends TestCase
         ))->cache($expectedTtl);
     }
 
-    #[Test]
+    /** @test */
     public function favicon_cannot_be_cached_if_it_is_already_cached(): void
     {
         Carbon::setTestNow(now());
@@ -124,7 +122,7 @@ final class FaviconTest extends TestCase
         ))->cache($expectedTtl);
     }
 
-    #[Test]
+    /** @test */
     public function favicon_can_be_cached_if_it_is_already_cached_and_the_force_flag_is_passed(): void
     {
         Carbon::setTestNow(now());
@@ -149,7 +147,7 @@ final class FaviconTest extends TestCase
         ))->cache(now()->addMinute(), true);
     }
 
-    #[Test]
+    /** @test */
     public function favicon_contents_be_stored(): void
     {
         Storage::fake();
@@ -169,7 +167,7 @@ final class FaviconTest extends TestCase
         self::assertSame('favicon contents here', Storage::get($path));
     }
 
-    #[Test]
+    /** @test */
     public function favicon_contents_be_stored_if_the_favicon_url_does_not_have_an_image_extension(): void
     {
         Storage::fake();
@@ -191,7 +189,7 @@ final class FaviconTest extends TestCase
         self::assertTrue(Str::of($path)->endsWith('.png'));
     }
 
-    #[Test]
+    /** @test */
     public function favicon_contents_can_be_stored_with_a_custom_file_name(): void
     {
         Storage::fake();
@@ -219,8 +217,11 @@ final class FaviconTest extends TestCase
         self::assertSame(Favicon::TYPE_ICON_UNKNOWN, $iconType);
     }
 
-    #[Test]
-    #[DataProvider('iconTypeProvider')]
+    /**
+     * @test
+     *
+     * @dataProvider iconTypeProvider
+     */
     public function icon_type_can_be_set_and_returned(string $expectedIconType): void
     {
         $iconType = (new Favicon(
@@ -233,8 +234,11 @@ final class FaviconTest extends TestCase
         self::assertSame($expectedIconType, $iconType);
     }
 
-    #[Test]
-    #[DataProvider('iconSizeProvider')]
+    /**
+     * @test
+     *
+     * @dataProvider iconSizeProvider
+     */
     public function icon_size_can_be_set_and_returned(?int $expectedIconSize): void
     {
         $iconSize = (new Favicon(
@@ -247,7 +251,7 @@ final class FaviconTest extends TestCase
         self::assertSame($expectedIconSize, $iconSize);
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_when_trying_to_create_a_favicon_with_an_invalid_icon_type(): void
     {
         $this->expectException(InvalidIconTypeException::class);
@@ -259,7 +263,7 @@ final class FaviconTest extends TestCase
         ))->setIconType('INVALID');
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_when_trying_to_create_a_favicon_with_an_invalid_icon_size(): void
     {
         $this->expectException(InvalidIconSizeException::class);

--- a/tests/Feature/FetcherManagerTest.php
+++ b/tests/Feature/FetcherManagerTest.php
@@ -15,13 +15,12 @@ use AshAllenDesign\FaviconFetcher\FetcherManager;
 use AshAllenDesign\FaviconFetcher\Tests\Feature\_data\CustomDriver;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Mockery;
-use PHPUnit\Framework\Attributes\Test;
 
-final class FetcherManagerTest extends TestCase
+class FetcherManagerTest extends TestCase
 {
     use LazilyRefreshDatabase;
 
-    #[Test]
+    /** @test */
     public function default_driver_can_be_returned(): void
     {
         config(['favicon-fetcher.default' => 'http']);
@@ -29,44 +28,44 @@ final class FetcherManagerTest extends TestCase
         self::assertInstanceOf(HttpDriver::class, FetcherManager::driver());
     }
 
-    #[Test]
+    /** @test */
     public function http_driver_can_be_returned(): void
     {
         self::assertInstanceOf(HttpDriver::class, FetcherManager::driver('http'));
     }
 
-    #[Test]
+    /** @test */
     public function google_shared_stuff_driver_can_be_returned(): void
     {
         self::assertInstanceOf(GoogleSharedStuffDriver::class, FetcherManager::driver('google-shared-stuff'));
     }
 
-    #[Test]
+    /** @test */
     public function favicon_kit_driver_can_be_returned(): void
     {
         self::assertInstanceOf(FaviconKitDriver::class, FetcherManager::driver('favicon-kit'));
     }
 
-    #[Test]
+    /** @test */
     public function favicon_grabber_driver_can_be_returned(): void
     {
         self::assertInstanceOf(FaviconGrabberDriver::class, FetcherManager::driver('favicon-grabber'));
     }
 
-    #[Test]
+    /** @test */
     public function duck_duck_go_driver_can_be_returned(): void
     {
         self::assertInstanceOf(DuckDuckGoDriver::class, FetcherManager::driver('duck-duck-go'));
     }
 
-    #[Test]
+    /** @test */
     public function custom_driver_can_be_returned(): void
     {
         FetcherManager::extend('custom-driver', new CustomDriver());
         self::assertInstanceOf(CustomDriver::class, FetcherManager::driver('custom-driver'));
     }
 
-    #[Test]
+    /** @test */
     public function exception_is_thrown_if_the_driver_is_invalid(): void
     {
         $this->expectException(FaviconFetcherException::class);
@@ -75,7 +74,7 @@ final class FetcherManagerTest extends TestCase
         FetcherManager::driver('invalid');
     }
 
-    #[Test]
+    /** @test */
     public function method_calls_to_the_manager_are_forwarded_to_the_driver(): void
     {
         $mock = tap(
@@ -94,7 +93,7 @@ final class FetcherManagerTest extends TestCase
         (new FetcherManager())->fetch('https://example.com');
     }
 
-    #[Test]
+    /** @test */
     public function method_calls_to_the_manager_are_forwarded_to_the_driver_using_the_facade(): void
     {
         $mock = tap(
@@ -113,7 +112,7 @@ final class FetcherManagerTest extends TestCase
         Favicon::fetch('https://example.com');
     }
 
-    #[Test]
+    /** @test */
     public function driver_can_be_returned_using_the_facade(): void
     {
         self::assertInstanceOf(FaviconKitDriver::class, Favicon::driver('favicon-kit'));


### PR DESCRIPTION
While we're still supporting PHPUnit 9 in development, I'll revert this PR. When support for PHPUnit is dropped, I'll re-add these changes so we're using the newer syntax for tests 😄